### PR TITLE
Add failing spec for verify-nth-call-args-for

### DIFF
--- a/test/conjure/core_test.clj
+++ b/test/conjure/core_test.clj
@@ -171,3 +171,7 @@
                  #"cannot be called from within"
                  (mocking [str])))))
 
+(deftest test-allows-verification-of-stubbed-functions
+  (stubbing [inc 3]
+            (inc 3)
+            (verify-nth-call-args-for 1 inc 3)))


### PR DESCRIPTION
Please correct me if I'm using verify-nth-call-args-for wrong, but checked docs and it says that i can verify stubbed stuff so assumed this should work.
Would love to fix it, but need some advice (I'm a newbie-macro-writer).

Cheers!
